### PR TITLE
kafka messege key 공백처리 및 serialization 메서드 변경

### DIFF
--- a/fake_person_producer.py
+++ b/fake_person_producer.py
@@ -1,5 +1,5 @@
+import re
 import uuid
-import json
 from typing import List
 from person import Person
 
@@ -46,8 +46,8 @@ def main():
         people.append(person)
         producer.send(
             topic=topic_name,
-            key=person.title.lower().replace(r's+', '-').encode('utf-8'),
-            value=person.json().encode('utf-8'))
+            key=re.sub(r'\s+', '-', person.title.lower()).encode('utf-8'),
+            value=person.model_dump_json().encode('utf-8'))
 
     producer.flush()
 


### PR DESCRIPTION
관련 issue: #1 

- replace 메서드에서는 정규표현식을 사용 할 수 없으므로, 정규표현식을 사용해서 공백문자를 처리
- pydantic 버전 2 부터 json 메서드 대신에, model_dump_json 메서드 사용
    - 참조: [pydantic migration](https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel)

Changes to be committed:
    modified:   fake_person_producer.py